### PR TITLE
Using translate for smooth animation of the progress bar

### DIFF
--- a/confidence.css
+++ b/confidence.css
@@ -13,6 +13,16 @@ svg .ci_significant_ugly    {fill: #761b9e !important; }
 svg .est                    {stroke: white; stroke-width: 4px; stroke-linecap: round; stroke-dasharray: 0, 7; stroke-dashoffset: -6;}
 svg .line                   {stroke: white; stroke-width: 4px; opacity: 1; }
 
+.progress {
+    transform: translateZ(0);
+}
+
+.progress-bar {
+    transform-origin: 0 0;
+    /*transition: translate3d 0.6s ease !important;*/
+    width: 100% !important;
+}
+
 .panel-hover:hover {
     border-color: #337ab7;
 }

--- a/index.html
+++ b/index.html
@@ -78,7 +78,7 @@
 			</div>
 			<div class="row" v-if="game_mode == 'arcade' && game_state == 'play'">
 				<div class="progress">
-					<div class="progress-bar" role="progressbar" :aria-valuenow="(time/TOTAL_VISITORS*100).toFixed(0)" aria-valuemin="0" aria-valuemax="100" :style="{width: (time/TOTAL_VISITORS*100).toFixed(0)+'%'}"></div>
+					<div class="progress-bar" role="progressbar" :aria-valuenow="progressNumRounded" aria-valuemin="0" aria-valuemax="100" :style="progressStyle"></div>
 				</div>
 			</div>
 
@@ -161,6 +161,19 @@
 					winner: 0,
 					game_mode: '',
 					game_state: '',
+				},
+				computed: {
+					progressNum: function () {
+						return (this.time/this.TOTAL_VISITORS*100);
+					},
+					progressNumRounded: function () {
+						return this.progressNum.toFixed(0);
+					},
+					progressStyle: function () {
+						return {
+							transform: 'translate3d(' + (this.progressNum - 100) + '%, 0, 0)'
+						}
+					}
 				},
 				methods: {
 					update_summary_statistics: function() {


### PR DESCRIPTION
**Main change:**
Progress bar animation was happening with width. Using width for animation is pretty heavy for the browser and was affecting animation of all the page.

That's the reason why it was having some lag. Translate animations are much more optimized and you can see the effect with a smooth progress bar (and no need of css transition now).

**Experiment data in vue**
With this change, I brought experiment data inside Vue again and the fps drop was by 1-4 frames. I decided to not touch that part as there was still a drop.

**Computed values instead of method calls in template**
No impact on performance or update of values here. this was a nice learning

**Result**
Chrome Developer tool says the current fps is ~24.

Let me know if you still see need of improvement. I can look further.

Marcelo