### PR TITLE
make sure vue is using vuefire

### DIFF
--- a/index.html
+++ b/index.html
@@ -305,7 +305,6 @@
     <script src="https://www.gstatic.com/firebasejs/4.8.1/firebase.js"></script>
     <script src="https://unpkg.com/vue/dist/vue.js"></script>
     <script src="https://unpkg.com/vuefire/dist/vuefire.js"></script>
-    <script src="https://unpkg.com/rtdb/rtdb.js"></script>
     <script type="text/javascript" src="d3/d3.min.js"></script>
     <script type="text/javascript" src="jstat/jstat.min.js"></script>
     <script type="text/javascript" src="experiment.js"></script>
@@ -342,6 +341,8 @@
         var errorMessage = error.message;
         console.log('ERROR '+errorCode+': '+errorMessage);
       });
+
+      Vue.use(Vuefire.rtdbPlugin);
 
       confidence = new Vue({
         el: '#app-confidence',


### PR DESCRIPTION
@heinrich333 asked me to check out why your app isn't working any longer since the update from vuefire. So I found out that the Vue Instance isn't aware of Vuefire and therefore not using it due to the fact of the missing `Vue.use(PLUGINNAME)`. But I only used Vue with a compiler yet so I don't know which additional requirement needs to be met in order to make Vuefire/firebase working again for this App.

So but tldr; after I integrated the missing `Vue.use()` the Error Message was gone and I now receive a error with tells me that I don't have permissions to the desired data. Maybe that has something to do, that I worked with a local environment with not beeing logged in into twitter.

So please check out if my fix is working in your environment!