### PR TITLE
Leaderboard unbind fixed (unbind -> rtdbUnbind)

### DIFF
--- a/index.html
+++ b/index.html
@@ -577,7 +577,7 @@
             });
           },
           rebind_leaderboard: function() {
-            this.$unbind('leaderboard');
+            this.$rtdbUnbind('leaderboard');
             this.bind_leaderboard();
           },
           bind_leaderboard: function() {


### PR DESCRIPTION
Leaderboard didn't refresh when switching game mods because of deprecated function